### PR TITLE
Fix uninit memory

### DIFF
--- a/include/cpbwt.h
+++ b/include/cpbwt.h
@@ -5,7 +5,7 @@ namespace CPBWT{
 	{
 		int prev_fr0, prev_fr1;
 		int prev_gr0, prev_gr1;
-		int *pbwt;
+		std::vector<int> pbwt;
 		int *v; //lookuptables
 		CipherTextVec efq, egq;
 		Elgamal::CipherText efp, egp;

--- a/src/cpbwt.cpp
+++ b/src/cpbwt.cpp
@@ -50,7 +50,7 @@ void CPBWT::Server::readPBWT(int m, int n, std::string pbwtfile)
 {
 	snps=n;
 	samples=m;
-	pbwt = (int *)malloc(sizeof(int)*m*n);
+	pbwt.resize(n*n);
 	std::ifstream ifs(pbwtfile.c_str());
 	std::string tmp;
 	char ch;
@@ -58,14 +58,8 @@ void CPBWT::Server::readPBWT(int m, int n, std::string pbwtfile)
 		ifs >> tmp;
 		for (int i=0;i<m;i++){
 			ch = tmp[i];
-			if(ch=='1')
-			switch(ch){
-			case '0':
-				pbwt[j*m+i] = 0;
-				break;
-			case '1':
+			if(ch=='1'){
 				pbwt[j*m+i] = 1;
-				break;
 			}
 		}
 	}

--- a/src/cpbwt.cpp
+++ b/src/cpbwt.cpp
@@ -58,9 +58,7 @@ void CPBWT::Server::readPBWT(int m, int n, std::string pbwtfile)
 		ifs >> tmp;
 		for (int i=0;i<m;i++){
 			ch = tmp[i];
-			if(ch=='1'){
-				pbwt[j*m+i] = 1;
-			}
+			pbwt[j*m+i] = (ch == '1') ? 1 : 0;
 		}
 	}
 }

--- a/src/cpbwt.cpp
+++ b/src/cpbwt.cpp
@@ -50,7 +50,7 @@ void CPBWT::Server::readPBWT(int m, int n, std::string pbwtfile)
 {
 	snps=n;
 	samples=m;
-	pbwt.resize(n*n);
+	pbwt.resize(m*n);
 	std::ifstream ifs(pbwtfile.c_str());
 	std::string tmp;
 	char ch;


### PR DESCRIPTION
At the original code

```
if(ch=='1')
switch(ch){
    case '0':
    pbwt[j*m+i] = 0;
    break;
case '1':
    pbwt[j*m+i] = 1;
    break;
}
```

`pbw[j*m+i] = 0;` is ignored and the value is uninitialized if ch != '1'.
